### PR TITLE
feat: evaluate source value as thruty by default

### DIFF
--- a/src/classnames.data.ts
+++ b/src/classnames.data.ts
@@ -451,6 +451,60 @@ const data: Array<{ title: string; variation: Variations; sources: Array<Source>
       },
     },
   },
+  {
+    title: "empty ouput when source is falsy: string",
+    sources: [{ color: "" }],
+    variation: { color: [blue, red].join(" ") },
+    expect: "",
+  },
+  {
+    title: "empty ouput when source is falsy: undefined",
+    sources: [{ color: undefined }],
+    variation: { color: [blue, red].join(" ") },
+    expect: "",
+  },
+  {
+    title: "empty ouput when source is falsy: null",
+    sources: [{ color: null }],
+    variation: { color: [blue, red].join(" ") },
+    expect: "",
+  },
+  {
+    title: "empty ouput when source is falsy: number",
+    sources: [{ color: 0 }],
+    variation: { color: [blue, red].join(" ") },
+    expect: "",
+  },
+  {
+    title: "empty ouput when source is falsy: boolean",
+    sources: [{ color: false }],
+    variation: { color: [blue, red].join(" ") },
+    expect: "",
+  },
+  {
+    title: "valid ouput when source is thruthy: string",
+    sources: [{ color: "123" }],
+    variation: { color: [blue, red].join(" ") },
+    expect: [blue, red].join(" "),
+  },
+  {
+    title: "valid ouput when source is thruthy: number",
+    sources: [{ color: 123 }],
+    variation: { color: [blue, red].join(" ") },
+    expect: [blue, red].join(" "),
+  },
+  {
+    title: "valid ouput when source is thruthy: boolean",
+    sources: [{ color: true }],
+    variation: { color: [blue, red].join(" ") },
+    expect: [blue, red].join(" "),
+  },
+  {
+    title: "valid ouput when source is thruthy: object",
+    sources: [{ color: {} }],
+    variation: { color: [blue, red].join(" ") },
+    expect: [blue, red].join(" "),
+  },
 ];
 
 export default data;

--- a/src/classnames.ts
+++ b/src/classnames.ts
@@ -60,8 +60,8 @@ export function get(
   // there is no further variatios to inspect, we're dealing with props -> css class case here
   // we need to finish the execution at this point
   if (isString(valueVariations)) {
-    // prop -> css class basically means include classes when prop value is `true`
-    if (correspondingSourceValue === true) return valueVariations;
+    // prop -> css class basically means include classes when prop value is `truthy`
+    if (Boolean(correspondingSourceValue) === true) return valueVariations;
 
     // prop -> css class and prop value is not true, this is no match so we should return nothing
     return null;
@@ -110,12 +110,14 @@ function classnames(variations: Variations, ...inputs: Array<Source | null | und
   const sources = inputs.filter((source) => !isNil(source)) as Source[];
 
   const alwaysVar = getAlwaysVariation(variations);
+
   const vars = Object.keys(variations).map((prop) => {
     if (isAlways(prop) && (isString(alwaysVar) || isNil(alwaysVar))) {
       return alwaysVar;
     }
 
     const variation = variations[prop];
+
     if (isNil(variation)) {
       return null;
     }


### PR DESCRIPTION
## By definition

## Excerpt from https://developer.mozilla.org/en-US/docs/Glossary/Truthy:
In [JavaScript](https://developer.mozilla.org/en-US/docs/Glossary/JavaScript), a truthy value is a value that is considered true when encountered in a [Boolean](https://developer.mozilla.org/en-US/docs/Glossary/Boolean) context. All values are truthy unless they are defined as [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) (i.e., except for false, 0, -0, 0n, "", null, undefined, and NaN).
